### PR TITLE
ignore stratification during imputation if there are strata with all NA

### DIFF
--- a/R/remove_outliers.R
+++ b/R/remove_outliers.R
@@ -4,19 +4,50 @@
 #' Wrapper around `outlier_pca_lof()` with conveniences:
 #' - Select a subset of columns (`target_cols`)
 #' - Exclude QC rows from outlier detection
-#' - Temporarily impute missing values (half of min) for detection
-#' - **New:** apply detection independently within strata (`strata`)
+#' - Temporarily impute missing values (half of column minimum) for detection
+#' - Apply detection independently within user-defined strata (`strata`)
+#'
+#' @details
+#' ## Stratification
+#' Set `strata` to:
+#' - `NULL` (default) to run detection once over all non-QC rows, or
+#' - a single column name in `df`, or
+#' - an external vector (length `nrow(df)`) to group samples.
+#'
+#' Outlier detection is performed **independently within each stratum** on non-QC rows
+#' (QC rows are always excluded from detection but retained in the output). Strata with
+#' fewer than 5 non-QC samples are skipped (no outliers removed for that stratum).
+#'
+#' ## Missing-data policy
+#' - If `impute_method = NULL` and any `target_cols` contain missing values among non-QC rows,
+#'   the function **errors** and lists the affected columns with counts. Enable
+#'   `impute_method = "half-min-value"` or resolve missingness beforehand.
+#' - If `impute_method = "half-min-value"`:
+#'   - The function first checks for target columns that are **entirely `NA` across all non-QC rows**.
+#'     If any exist, it **errors** (a half-minimum cannot be computed).
+#'   - It then checks, **per stratum**, for target columns that are entirely `NA` **within that stratum**.
+#'     If any are found, a **warning** is emitted listing the affected strata and columns, and
+#'     **temporary imputation is applied on the whole non-QC dataset (ignoring stratification)**,
+#'     while outlier detection still runs **per stratum** as requested.
+#' - After outlier removal, if `restore_missing_values = TRUE`, the original `NA`s in `target_cols`
+#'   are restored in the returned data.
 #'
 #' @param df A data.frame with features in columns and samples in rows.
-#' @param target_cols Character vector of column names (or tidyselect helpers if supported by `resolve_target_cols()`).
-#'   If `NULL`, uses `resolve_target_cols(df, NULL)` to infer targets.
-#' @param is_qc Logical vector (length `nrow(df)`) marking QC rows to exclude from detection. Defaults to all `FALSE`.
+#' @param target_cols Character vector of column names (or tidyselect helpers if supported by
+#'   `resolve_target_cols()`). If `NULL`, uses `resolve_target_cols(df, NULL)` to infer targets.
+#' @param is_qc Logical vector (length `nrow(df)`) marking QC rows to exclude from detection.
+#'   Defaults to all `FALSE`.
 #' @param method Character; currently supports `"pca-lof-overall"` (default behavior).
-#' @param impute_method `NULL` or `"half-min-value"`. If set, imputation is applied **within each stratum** on `target_cols`.
-#' @param restore_missing_values Logical; if `TRUE`, original `NA`s in `target_cols` are restored after filtering.
+#' @param impute_method `NULL` or `"half-min-value"`. When set, missing values in `target_cols`
+#'   are imputed as half the minimum non-missing value—by default **within each stratum**; if any
+#'#'   stratum has a target column entirely `NA`, imputation is performed **globally** on non-QC rows
+#'   (see Missing-data policy).
+#' @param restore_missing_values Logical; if `TRUE`, original `NA`s in `target_cols` are restored
+#'   after filtering.
 #' @param return_ggplots Logical; if `TRUE`, returns a named list of ggplots per stratum.
-#' @param strata `NULL` (default), a single column name in `df`, or an external vector of length `nrow(df)`.
-#'   When provided, outlier detection is run independently within each stratum (QC rows always excluded within the stratum).
+#' @param strata `NULL` (default), a single column name in `df`, or an external vector of length
+#'   `nrow(df)`. When provided, outlier detection is run independently within each stratum
+#'   (QC rows excluded within the stratum).
 #'
 #' @return A list with:
 #' \describe{
@@ -26,17 +57,47 @@
 #' }
 #'
 #' @export
+#'
 #' @examples
-#' # No stratification (current behavior)
-#' # remove_outliers(df, target_cols = c("f1","f2"))
+#' # 1) No stratification
+#' remove_outliers(
+#'   df,
+#'   target_cols = c("f1","f2"),
+#'   impute_method = "half-min-value"
+#' )
 #'
-#' # Stratify by a column
-#' # remove_outliers(df, target_cols = c("f1","f2"), strata = "batch")
+#' # 2) Stratify by a column in df
+#' remove_outliers(
+#'   df,
+#'   target_cols = c("f1","f2"),
+#'   strata = "batch",
+#'   impute_method = "half-min-value"
+#' )
 #'
-#' # Stratify by an external vector
-#' # grp <- ifelse(df$batch %in% c("A","B"), "AB", "C")
-#' # remove_outliers(df, target_cols = c("f1","f2"), strata = grp)
+#' # 3) Stratify by an external vector
+#' my_strata <- c("A", "A", "B", "B", "B", "C", "C")
+#' remove_outliers(
+#'   df,
+#'   target_cols = c("f1","f2"),
+#'   strata = grp,
+#'   impute_method = "half-min-value"
+#' )
 #'
+#' # 4) Stratum with all-NA target columns -> triggers global temporary imputation (warning)
+#' \donttest{
+#' df2 <- data.frame(
+#'   f1 = c(1, 2, 3, NA, NA, NA),
+#'   f2 = c(2, 3, 4, NA, NA, NA),
+#'   batch = c("A","A","A","B","B","B")
+#' )
+#' rownames(df2) <- paste0("s", seq_len(nrow(df2)))
+#' remove_outliers(
+#'   df2,
+#'   target_cols = c("f1","f2"),
+#'   strata = "batch",
+#'   impute_method = "half-min-value"
+#' )
+#' }
 remove_outliers <- function(df,
                             target_cols = NULL,
                             is_qc = NULL,
@@ -62,7 +123,12 @@ remove_outliers <- function(df,
     if (!identical(outlier_removal_method, "pca-lof-overall")) {
         stop("Currently only `method = 'pca-lof-overall'` is supported.")
     }
-    impute_method <- match.arg(impute_method)
+    if (!is.null(impute_method)) {
+        impute_method <- match.arg(impute_method, choices = c("half-min-value"))
+        # impute_method <- NULL
+    } 
+    # else {
+    # }
 
     if (is.null(strata)) {
         strata_vec <- factor(rep(".all", nrow(df))) # single stratum
@@ -88,6 +154,80 @@ remove_outliers <- function(df,
         NULL
     }
 
+    tgt_non_qc <- df_non_qc[, target_cols, drop = FALSE]
+
+    if (is.null(impute_method)) {
+        na_counts <- colSums(is.na(tgt_non_qc))
+        if (any(na_counts > 0)) {
+            na_counts <- na_counts[na_counts > 0]
+            na_counts <- na_counts[order(na_counts, decreasing = TRUE)]
+            cols_with_na <- names(na_counts)
+            details <- paste0(cols_with_na, " (", na_counts, ")")
+            stop(
+                paste0(
+                    "Missing values detected in `target_cols` among non-QC rows while `impute_method = NULL`.\n",
+                    "Columns with missing values [n_missing]: ",
+                    paste(details, collapse = ", "), ".\n",
+                    "Either remove missingness beforehand or call with `impute_method = \"half-min-value\"`."
+                ),
+                call. = FALSE
+            )
+        }
+    }
+    
+    use_global_imputation <- FALSE
+    per_stratum_all_na <- list()
+
+    if (identical(impute_method, "half-min-value")) {
+        # If any target column is all NA across the whole non-QC dataset -> cannot impute
+        cols_all_na_glob <- vapply(tgt_non_qc, function(x) all(is.na(x)), logical(1))
+        if (any(cols_all_na_glob)) {
+            stop(
+                "The following `target_cols` are entirely missing across non-QC rows: ",
+                paste(names(cols_all_na_glob)[cols_all_na_glob], collapse = ", "),
+                ". Temporary imputation with half-min cannot proceed."
+            )
+        }
+
+        # Scan strata: if any (stratum, col) is all NA (non-QC rows within stratum), we flip to global imputation
+        levs <- levels(strata_vec)
+        for (lev in levs) {
+            idx_all <- which(strata_vec == lev)
+            idx_non_qc_stratum <- idx_all[!is_qc[idx_all]]
+            if (length(idx_non_qc_stratum) == 0L) next
+
+            sub <- df[idx_non_qc_stratum, target_cols, drop = FALSE]
+            cols_all_na <- vapply(sub, function(x) all(is.na(x)), logical(1))
+            if (any(cols_all_na)) {
+                use_global_imputation <- TRUE
+                per_stratum_all_na[[as.character(lev)]] <- names(cols_all_na)[cols_all_na]
+            }
+        }
+
+        if (use_global_imputation) {
+            msg <- paste0(
+                "\n\nDetected strata with columns entirely missing among non-QC rows. ",
+                "Applying temporary imputation on the whole non-QC dataset (ignoring stratification). ",
+                "Affected strata and columns:\n",
+                "strat : columns\n",
+                paste(
+                    vapply(names(per_stratum_all_na), function(k) {
+                        paste0("  - ", k, ": ", paste(per_stratum_all_na[[k]], collapse = ", "))
+                    }, character(1)),
+                    collapse = "\n"
+                )
+            )
+            warning(msg, call. = FALSE)
+
+            # Prepare a globally imputed copy for non-QC rows
+            imputed_non_qc <- df_non_qc
+            imputed_non_qc[, target_cols] <- impute_with_half_min(tgt_non_qc)
+        }
+    }
+
+    excluded_ids_all <- character(0)
+    plot_list <- if (isTRUE(return_ggplots)) list() else NULL
+
     # Iterate over levels; detection is done on NON-QC rows within each stratum
     for (lev in levels(strata_vec)) {
         idx_all <- which(strata_vec == lev)
@@ -102,10 +242,17 @@ remove_outliers <- function(df,
         rn_s <- rownames(df_s) # Keep rownames for back-mapping
         na_mask_s <- is.na(df_s[, target_cols, drop = FALSE]) # Save NA mask BEFORE imputation (only on target cols)
 
-        if (!is.null(impute_method) && identical(impute_method, "half-min-value")) {
-            df_s[, target_cols] <- impute_with_half_min(df_s[, target_cols, drop = FALSE])
+        if (identical(impute_method, "half-min-value")) {
+            if (isTRUE(use_global_imputation)) {
+                # take from globally-imputed non-QC copy
+                # map rownames to non-QC rows
+                rn <- rownames(df_s)
+                df_s[, target_cols] <- imputed_non_qc[rn, target_cols, drop = FALSE]
+            } else {
+                # per-stratum imputation
+                df_s[, target_cols] <- impute_with_half_min(df_s[, target_cols, drop = FALSE])
+            }
         }
-
         # Minimum size guard: PCA/LOF won’t behave with very small n
         # (you may tune this threshold to what the pca-lof detecter expects)
         if (nrow(df_s) < 5L) {

--- a/man/remove_outliers.Rd
+++ b/man/remove_outliers.Rd
@@ -18,21 +18,27 @@ remove_outliers(
 \arguments{
 \item{df}{A data.frame with features in columns and samples in rows.}
 
-\item{target_cols}{Character vector of column names (or tidyselect helpers if supported by \code{resolve_target_cols()}).
-If \code{NULL}, uses \code{resolve_target_cols(df, NULL)} to infer targets.}
+\item{target_cols}{Character vector of column names (or tidyselect helpers if supported by
+\code{resolve_target_cols()}). If \code{NULL}, uses \code{resolve_target_cols(df, NULL)} to infer targets.}
 
-\item{is_qc}{Logical vector (length \code{nrow(df)}) marking QC rows to exclude from detection. Defaults to all \code{FALSE}.}
+\item{is_qc}{Logical vector (length \code{nrow(df)}) marking QC rows to exclude from detection.
+Defaults to all \code{FALSE}.}
 
 \item{method}{Character; currently supports \code{"pca-lof-overall"} (default behavior).}
 
-\item{impute_method}{\code{NULL} or \code{"half-min-value"}. If set, imputation is applied \strong{within each stratum} on \code{target_cols}.}
+\item{impute_method}{\code{NULL} or \code{"half-min-value"}. When set, missing values in \code{target_cols}
+are imputed as half the minimum non-missing value—by default \strong{within each stratum}; if any
+#'   stratum has a target column entirely \code{NA}, imputation is performed \strong{globally} on non-QC rows
+(see Missing-data policy).}
 
-\item{restore_missing_values}{Logical; if \code{TRUE}, original \code{NA}s in \code{target_cols} are restored after filtering.}
+\item{restore_missing_values}{Logical; if \code{TRUE}, original \code{NA}s in \code{target_cols} are restored
+after filtering.}
 
 \item{return_ggplots}{Logical; if \code{TRUE}, returns a named list of ggplots per stratum.}
 
-\item{strata}{\code{NULL} (default), a single column name in \code{df}, or an external vector of length \code{nrow(df)}.
-When provided, outlier detection is run independently within each stratum (QC rows always excluded within the stratum).}
+\item{strata}{\code{NULL} (default), a single column name in \code{df}, or an external vector of length
+\code{nrow(df)}. When provided, outlier detection is run independently within each stratum
+(QC rows excluded within the stratum).}
 }
 \value{
 A list with:
@@ -47,19 +53,82 @@ Wrapper around \code{outlier_pca_lof()} with conveniences:
 \itemize{
 \item Select a subset of columns (\code{target_cols})
 \item Exclude QC rows from outlier detection
-\item Temporarily impute missing values (half of min) for detection
-\item \strong{New:} apply detection independently within strata (\code{strata})
+\item Temporarily impute missing values (half of column minimum) for detection
+\item Apply detection independently within user-defined strata (\code{strata})
+}
+}
+\details{
+\subsection{Stratification}{
+
+Set \code{strata} to:
+\itemize{
+\item \code{NULL} (default) to run detection once over all non-QC rows, or
+\item a single column name in \code{df}, or
+\item an external vector (length \code{nrow(df)}) to group samples.
+}
+
+Outlier detection is performed \strong{independently within each stratum} on non-QC rows
+(QC rows are always excluded from detection but retained in the output). Strata with
+fewer than 5 non-QC samples are skipped (no outliers removed for that stratum).
+}
+
+\subsection{Missing-data policy}{
+\itemize{
+\item If \code{impute_method = NULL} and any \code{target_cols} contain missing values among non-QC rows,
+the function \strong{errors} and lists the affected columns with counts. Enable
+\code{impute_method = "half-min-value"} or resolve missingness beforehand.
+\item If \code{impute_method = "half-min-value"}:
+\itemize{
+\item The function first checks for target columns that are \strong{entirely \code{NA} across all non-QC rows}.
+If any exist, it \strong{errors} (a half-minimum cannot be computed).
+\item It then checks, \strong{per stratum}, for target columns that are entirely \code{NA} \strong{within that stratum}.
+If any are found, a \strong{warning} is emitted listing the affected strata and columns, and
+\strong{temporary imputation is applied on the whole non-QC dataset (ignoring stratification)},
+while outlier detection still runs \strong{per stratum} as requested.
+}
+\item After outlier removal, if \code{restore_missing_values = TRUE}, the original \code{NA}s in \code{target_cols}
+are restored in the returned data.
+}
 }
 }
 \examples{
-# No stratification (current behavior)
-# remove_outliers(df, target_cols = c("f1","f2"))
+# 1) No stratification
+remove_outliers(
+  df,
+  target_cols = c("f1","f2"),
+  impute_method = "half-min-value"
+)
 
-# Stratify by a column
-# remove_outliers(df, target_cols = c("f1","f2"), strata = "batch")
+# 2) Stratify by a column in df
+remove_outliers(
+  df,
+  target_cols = c("f1","f2"),
+  strata = "batch",
+  impute_method = "half-min-value"
+)
 
-# Stratify by an external vector
-# grp <- ifelse(df$batch \%in\% c("A","B"), "AB", "C")
-# remove_outliers(df, target_cols = c("f1","f2"), strata = grp)
+# 3) Stratify by an external vector
+my_strata <- c("A", "A", "B", "B", "B", "C", "C")
+remove_outliers(
+  df,
+  target_cols = c("f1","f2"),
+  strata = grp,
+  impute_method = "half-min-value"
+)
 
+# 4) Stratum with all-NA target columns -> triggers global temporary imputation (warning)
+\donttest{
+df2 <- data.frame(
+  f1 = c(1, 2, 3, NA, NA, NA),
+  f2 = c(2, 3, 4, NA, NA, NA),
+  batch = c("A","A","A","B","B","B")
+)
+rownames(df2) <- paste0("s", seq_len(nrow(df2)))
+remove_outliers(
+  df2,
+  target_cols = c("f1","f2"),
+  strata = "batch",
+  impute_method = "half-min-value"
+)
+}
 }


### PR DESCRIPTION
When any stratum has only missing values in target columns, we warn and fall back to performing imputation globally while ignoring stratification, while keeping **per-stratum** outlier detection. When imputation is disabled and missing values exist, we **error** with a detailed, per-column missingness summary.

## What & Why

* **Problem:** Per-stratum temporary imputation fails when a stratum is all NA for some targets; and users weren’t guided when imputation was off but data had NAs.
* **Solution:**

  * If `impute_method = NULL` and non-QC rows have NAs → `stop()` listing all affected columns with counts.
  * If `impute_method = "half-min-value"` and any **stratum** has target columns all NA → `warning()`, then impute **globally** on non-QC data; run detection **per stratum** as requested.
  * If any target column is all NA **globally** among non-QC → `stop()` (half-min can’t be computed).

Add unit tests to check function's decision tree.

* Roxygen updated:

  * Clear **stratification** usage (column name or external vector).
  * Detailed **Missing-data policy**, including behavior for all-NA strata and global all-NA targets.
  * Expanded **@examples** covering: no stratification, by-column, external vector, all-NA stratum (warning), and error when imputation is off.
